### PR TITLE
Feature/performance measurement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ SET(SOURCE_FILES
     com/Server.h
     logging/Logger.cpp
     logging/Logger.h
+    logging/Performance.h
     logging/sqlite3.c
     logging/sqlite3.h
     logging/sqlite3ext.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ SET(SOURCE_FILES
     config/FileFormat.h
     com/Airport.cpp
     com/Airport.h
+    com/PerformanceLock.h
     com/Server.cpp
     com/Server.h
     logging/Logger.cpp

--- a/com/Airport.cpp
+++ b/com/Airport.cpp
@@ -15,16 +15,16 @@ static constexpr std::size_t FlightServer = 2;
 Airport::Airport() :
         m_airport(),
         m_worker(),
-        m_lock(),
         m_pause(false),
+        m_lock("EMPTY"),
         m_flights(),
         m_stop(false) { }
 
 Airport::Airport(const std::string& airport) :
         m_airport(airport),
         m_worker(),
-        m_lock(),
         m_pause(false),
+        m_lock(airport),
         m_flights(),
         m_stop(false) {
     const auto flights = Server::instance().allFlights(this->m_airport);

--- a/com/Airport.cpp
+++ b/com/Airport.cpp
@@ -16,6 +16,7 @@ Airport::Airport() :
         m_airport(),
         m_worker(),
         m_lock(),
+        m_pause(false),
         m_flights(),
         m_stop(false) { }
 
@@ -23,6 +24,7 @@ Airport::Airport(const std::string& airport) :
         m_airport(airport),
         m_worker(),
         m_lock(),
+        m_pause(false),
         m_flights(),
         m_stop(false) {
     const auto flights = Server::instance().allFlights(this->m_airport);

--- a/com/Airport.h
+++ b/com/Airport.h
@@ -29,6 +29,9 @@ private:
     PerformanceLock m_lock;
     std::map<std::string, std::array<types::Flight_t, 3>> m_flights;
     volatile bool m_stop;
+    logging::Performance m_manualUpdatePerformance;
+    logging::Performance m_workerAllFlightsPerformance;
+    logging::Performance m_workerUpdateFlightsPerformance;
 
     static std::string timestampToIsoString(const std::chrono::utc_clock::time_point& timepoint);
     static SendType deltaEuroscopeToBackend(const std::array<types::Flight_t, 3>& data, Json::Value& root);

--- a/com/Airport.h
+++ b/com/Airport.h
@@ -10,6 +10,8 @@
 
 #include <types/Flight.h>
 
+#include "PerformanceLock.h"
+
 namespace vacdm {
 namespace com {
 
@@ -24,7 +26,7 @@ private:
     std::string m_airport;
     std::thread m_worker;
     volatile bool m_pause;
-    std::mutex m_lock;
+    PerformanceLock m_lock;
     std::map<std::string, std::array<types::Flight_t, 3>> m_flights;
     volatile bool m_stop;
 

--- a/com/PerformanceLock.h
+++ b/com/PerformanceLock.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <mutex>
+
+#include <logging/Performance.h>
+
+namespace vacdm {
+namespace com {
+    class PerformanceLock {
+    private:
+        vacdm::logging::Performance m_acquireTime;
+        vacdm::logging::Performance m_criticalSectionTime;
+
+        std::mutex m_lock;
+    public:
+        PerformanceLock(const std::string& component) :
+            m_acquireTime("LockAcquire" + component),
+            m_criticalSectionTime("CriticalSectionAcquire" + component),
+            m_lock() {}
+
+        void lock() {
+            this->m_acquireTime.start();
+            this->m_lock.lock();
+            this->m_acquireTime.stop();
+
+            this->m_criticalSectionTime.start();
+        }
+
+        void unlock() {
+            this->m_lock.unlock();
+            this->m_criticalSectionTime.stop();
+        }
+    };
+}
+}

--- a/logging/Performance.h
+++ b/logging/Performance.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <string>
+
+#include "Logger.h"
+
+#define PERFORMANCE_MEASUREMENT 1
+
+namespace vacdm {
+namespace logging {
+    class Performance {
+    private:
+        std::string m_name;
+        std::uint64_t m_average;
+        std::int64_t m_minimum;
+        std::int64_t m_maximum;
+        std::uint32_t m_cycleCount;
+        std::chrono::high_resolution_clock::time_point m_startTime;
+        std::chrono::high_resolution_clock::time_point m_lastLogStamp;
+
+    public:
+        Performance(const std::string& name) :
+            m_name(name),
+            m_average(0),
+            m_minimum(std::numeric_limits<std::uint32_t>::max()),
+            m_maximum(std::numeric_limits<std::uint32_t>::min()),
+            m_cycleCount(0),
+            m_startTime(),
+            m_lastLogStamp(std::chrono::high_resolution_clock::now()) {}
+
+        void start() {
+#if PERFORMANCE_MEASUREMENT
+            this->m_startTime = std::chrono::high_resolution_clock::now();
+#endif
+        }
+
+        void stop() {
+#if PERFORMANCE_MEASUREMENT
+            const auto now = std::chrono::high_resolution_clock::now();
+            const auto delta = std::chrono::duration_cast<std::chrono::microseconds>(now - this->m_startTime).count();
+
+            this->m_minimum = std::min(this->m_minimum, delta);
+            this->m_maximum = std::max(this->m_maximum, delta);
+            if (this->m_cycleCount == 0)
+                this->m_average = delta;
+            else
+                this->m_average = static_cast<std::uint32_t>((this->m_average + delta) * 0.5);
+
+            if (std::chrono::duration_cast<std::chrono::minutes>(now - this->m_lastLogStamp).count() >= 1) {
+                std::stringstream stream;
+                stream << "Performance statistics:" << std::endl;
+                stream << "    Average: " << std::to_string(this->m_average) << " us" << std::endl;
+                stream << "    Minimum: " << std::to_string(this->m_minimum) << " us" << std::endl;
+                stream << "    Maximum: " << std::to_string(this->m_maximum) << " us" << std::endl;
+
+                Logger::instance().log("Performance-" + this->m_name, Logger::Level::Info, stream.str());
+
+                this->m_lastLogStamp = now;
+            }
+#endif
+        }
+    };
+}
+}


### PR DESCRIPTION
Introduces a performance measurement framework for mutex and other sections.
Every minute are statistics written to the internal log file

Example results of components
![grafik](https://user-images.githubusercontent.com/64070348/233855154-74772f55-99de-4930-bd96-166eb8944927.png)

Example result of one statistic entry:
![grafik](https://user-images.githubusercontent.com/64070348/233855168-8b46b526-789c-4620-9c92-c3cb39c9e076.png)
