### PR TITLE
Ignore simulated position updates

### DIFF
--- a/src/core/DataManager.cpp
+++ b/src/core/DataManager.cpp
@@ -287,6 +287,11 @@ DataManager::MessageType DataManager::deltaEuroscopeToBackend(const std::array<t
                                                               Json::Value& message) {
     message.clear();
 
+    // Do not push updates to server if simulated update
+    if (!data[EuroscopeData].isSimulated) {
+        return DataManager::MessageType::None;
+    }
+
     if (data[ServerData].callsign == "" && data[EuroscopeData].callsign != "") {
         return DataManager::MessageType::Post;
     } else {
@@ -516,6 +521,7 @@ types::Pilot DataManager::CFlightPlanToPilot(const EuroScopePlugIn::CFlightPlan 
     // position data
     pilot.latitude = flightplan.GetFPTrackPosition().GetPosition().m_Latitude;
     pilot.longitude = flightplan.GetFPTrackPosition().GetPosition().m_Longitude;
+    pilot.isSimulated = flightplan.GetSimulated();
 
     // flightplan & clearance data
     pilot.origin = flightplan.GetFlightPlanData().GetOrigin();

--- a/src/types/Pilot.h
+++ b/src/types/Pilot.h
@@ -20,6 +20,7 @@ typedef struct Pilot_t {
     double latitude = 0.0;
     double longitude = 0.0;
     bool taxizoneIsTaxiout = false;
+    bool isSimulated = false;
 
     // flightplan & clearance data
 


### PR DESCRIPTION
  Plugins get simulated traffic update even when the box is unticked in Euroscope settings (it's just a display flag). This ensures no simulated traffic update is propagated to the server