### PR TITLE
Disable client-side `inactive` flag toggling

### DIFF
--- a/src/core/DataManager.cpp
+++ b/src/core/DataManager.cpp
@@ -294,11 +294,6 @@ DataManager::MessageType DataManager::deltaEuroscopeToBackend(const std::array<t
 
         int deltaCount = 0;
 
-        if (data[EuroscopeData].inactive != data[ServerData].inactive) {
-            message["inactive"] = data[EuroscopeData].inactive;
-            deltaCount += 1;
-        }
-
         auto lastDelta = deltaCount;
         message["position"] = Json::Value();
         if (data[EuroscopeData].latitude != data[ServerData].latitude) {


### PR DESCRIPTION
This seems to cause issues with pilots appearing and disappearing very fast in the backend (possible race condition).

Idea is to toggle flag only server-side and client just gets whatever is active